### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.200</version>
+            <version>2.1.210</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.h2database:h2 1.4.200
- [CVE-2021-42392](https://www.oscs1024.com/hd/CVE-2021-42392)


### What did I do？
Upgrade com.h2database:h2 from 1.4.200 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS